### PR TITLE
Add support for additional flags/properties to the resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,23 @@ Syntax:
 
 ```ruby
 remote_execute 'name' do
-  address     String          #
-  command     String, Array   # defaults to name
-  returns     Integer, Array  #
-  password    String          #
-  user        String          #
-  timeout     Integer         # default: 60
-  input       String          #
-  interactive boolean         # default: false
-  request_pty boolean         # default: false
+  address           String          #
+  command           String, Array   # default: name
+  returns           Integer, Array  #
+  password          String          #
+  user              String          #
+  timeout           Integer         # default: 60
+  input             String          #
+  interactive       boolean         # default: false
+  request_pty       boolean         # default: false
+  sensitive         boolean         # default: false
+  sensitive_command boolean         # default: sensitive
+  sensitive_output  boolean         # default: sensitive
 
   not_if_remote String, Array, Hash # Remotely executed shell guard command like not_if
   only_if_remote String, Array, Hash # Remotely executed shell guard command like only_if
 
-  action    Symbol            # defaults to :run
+  action    Symbol                  # default: :run
 end
 ```
 
@@ -75,6 +78,20 @@ The resource has the following properties:
     **Note:** Using a PTY will merge the standard output and standard error
     streams of the executed command.
 
+* `sensitive`: If true, `sensitive_output` and `sensitive_command` default to
+  true instead of false.
+
+* `sensitive_output` (default: `sensitive`). 
+
+  If enabled for a command or guard (the same selection semantics as for
+  `request_pty` apply), the standard output and standard error streams will not
+  be printed, either directly or in error messages.
+
+* `sensitive_command` (default: `sensitive`).
+
+  If enabled for a command or guard (the same selection semantics as for
+  `request_pty` apply), the commands will not be printed.
+
 #### Guards
 
 ##### Synopsis
@@ -84,8 +101,10 @@ following keys:
 
 ```ruby
 {
-    command: [String, Array],  # the command to execute as array or string
-    request_pty: [TrueClass, FalseClass]  # whether to request a pty. default: false
+    command: [String, Array],
+    request_pty: [TrueClass, FalseClass],  # default: false
+    sensitive_output: [TrueClass, FalseClass],  # default: sensitive
+    sensitive_command: [TrueClass, FalseClass]  # default: sensitive
 }
 ```
 
@@ -96,6 +115,11 @@ If a string or array is given instead of a hash, the `value` is converted to
   details.
 * `request_pty`: Whether to request a PTY for the guard execution. See the
   properties above for details on the implications of requesting a PTY.
+* `sensitive_output`: Whether to suppress printing the output of the guard
+  command. The default is true if the resource is marked as sensitive, false
+  otherwise.
+* `sensitive_command`: Whether to suppress printing the guard command itself.
+  The default is true if the resource is marked as sensitive, false otherwise.
 
 ##### Description
 

--- a/libraries/validation.rb
+++ b/libraries/validation.rb
@@ -1,0 +1,23 @@
+module RemoteExec
+  module Validation
+    def self.coerce_guard_config(guard_config)
+      guard_config = { command: guard_config } if guard_config.is_a?(Array) || guard_config.is_a?(String)
+      raise 'remote guards must be either a String, an Array or a Hash' unless guard_config.is_a?(Hash)
+      guard_config[:request_pty] = false unless guard_config.key?(:request_pty)
+      guard_config
+    end
+
+    def self.guard_config_checks
+      # :request_pty is defaulted in coerce
+      required_keys = [:command, :request_pty]
+      allowed_keys = required_keys + []
+
+      {
+        "must be Hash with keys #{required_keys}" => ->(v) { required_keys.all? { |key| v.key?(key) } },
+        "must be Hash with only keys #{allowed_keys}" => ->(v) { v.keys.all? { |key| allowed_keys.include?(key) } },
+        ':command must be Array or String' => ->(v) { v[:command].is_a?(Array) || v[:command].is_a?(String) },
+        ':request_pty must be boolean' => ->(v) { v[:request_pty] == true || v[:request_pty] == false },
+      }
+    end
+  end
+end

--- a/libraries/validation.rb
+++ b/libraries/validation.rb
@@ -1,15 +1,17 @@
 module RemoteExec
   module Validation
-    def self.coerce_guard_config(guard_config)
+    def self.coerce_guard_config(guard_config, sensitive_default)
       guard_config = { command: guard_config } if guard_config.is_a?(Array) || guard_config.is_a?(String)
       raise 'remote guards must be either a String, an Array or a Hash' unless guard_config.is_a?(Hash)
       guard_config[:request_pty] = false unless guard_config.key?(:request_pty)
+      guard_config[:sensitive_output] = sensitive_default unless guard_config.key?(:sensitive_output)
+      guard_config[:sensitive_command] = sensitive_default unless guard_config.key?(:sensitive_command)
       guard_config
     end
 
     def self.guard_config_checks
       # :request_pty is defaulted in coerce
-      required_keys = [:command, :request_pty]
+      required_keys = [:command, :request_pty, :sensitive_output, :sensitive_command]
       allowed_keys = required_keys + []
 
       {
@@ -17,6 +19,8 @@ module RemoteExec
         "must be Hash with only keys #{allowed_keys}" => ->(v) { v.keys.all? { |key| allowed_keys.include?(key) } },
         ':command must be Array or String' => ->(v) { v[:command].is_a?(Array) || v[:command].is_a?(String) },
         ':request_pty must be boolean' => ->(v) { v[:request_pty] == true || v[:request_pty] == false },
+        ':sensitive_output must be boolean' => ->(v) { v[:sensitive_output] == true || v[:sensitive_output] == false },
+        ':sensitive_command must be boolean' => ->(v) { v[:sensitive_command] == true || v[:sensitive_command] == false },
       }
     end
   end

--- a/resources/remote_execute.rb
+++ b/resources/remote_execute.rb
@@ -26,9 +26,11 @@ property :address, String, required: true
 property :input, String
 property :interactive, [TrueClass, FalseClass], default: false
 property :request_pty, [TrueClass, FalseClass], default: false
+property :sensitive_output, [TrueClass, FalseClass], default: lazy { sensitive }
+property :sensitive_command, [TrueClass, FalseClass], default: lazy { sensitive }
 
-property :not_if_remote, [String, Array, Hash], coerce: proc { |v| RemoteExec::Validation.coerce_guard_config(v) }, callbacks: RemoteExec::Validation.guard_config_checks
-property :only_if_remote, [String, Array, Hash], coerce: proc { |v| RemoteExec::Validation.coerce_guard_config(v) }, callbacks: RemoteExec::Validation.guard_config_checks
+property :not_if_remote, [String, Array, Hash], coerce: proc { |v| RemoteExec::Validation.coerce_guard_config(v, sensitive) }, callbacks: RemoteExec::Validation.guard_config_checks
+property :only_if_remote, [String, Array, Hash], coerce: proc { |v| RemoteExec::Validation.coerce_guard_config(v, sensitive) }, callbacks: RemoteExec::Validation.guard_config_checks
 
 action :run do
   Chef::Log.debug('remote_execute.rb: action_run')
@@ -39,7 +41,12 @@ action :run do
                          [new_resource.returns]
                        end
 
-  if !new_resource.input.nil? && new_resource.request_pty
+  command_options = {
+    input: new_resource.input,
+    request_pty: new_resource.request_pty,
+  }
+
+  if !new_resource.input.nil? && command_options.fetch(:request_pty)
     # XXX: IF we ever allow input with PTYs, the .eof! method used below will
     # not work. Instead, we have to send double-\x04 (Ctrl+D a.k.a. End Of
     # Tranmission ASCII control code) to signal EOF. This is all super-fragile
@@ -49,36 +56,37 @@ action :run do
 
   ssh_session do |session|
     if !new_resource.not_if_remote.nil? && !new_resource.not_if_remote.empty?
-      break if eval_guard(session, new_resource.not_if_remote)
+      result = !eval_guard(session, new_resource.not_if_remote)
+      Chef::Log.info("#{new_resource}: evaluated not_if_remote #{masked_command(new_resource.not_if_remote.fetch(:command).inspect, new_resource.not_if_remote.fetch(:sensitive_command))}. may proceed = #{result}")
+      break unless result
     end
     if !new_resource.only_if_remote.nil? && !new_resource.only_if_remote.empty?
-      break unless eval_guard(session, new_resource.only_if_remote)
+      result = eval_guard(session, new_resource.only_if_remote)
+      Chef::Log.info("#{new_resource}: evaluated only_if_remote #{masked_command(new_resource.only_if_remote.fetch(:command).inspect, new_resource.only_if_remote.fetch(:sensitive_command))}. may proceed = #{result}")
+      break unless result
     end
 
-    descriptor = "#{new_resource.command.inspect} on server #{new_resource.address.inspect} as #{new_resource.user.inspect}"
+    descriptor = "#{masked_command(new_resource.command.inspect, new_resource.sensitive_command)} on server #{new_resource.address.inspect} as #{new_resource.user.inspect}"
+
     converge_by("execute #{descriptor}") do
-      r = ssh_exec(session, new_resource.command,
-                   input: new_resource.input,
-                   request_pty: new_resource.request_pty)
-      Chef::Log.debug("remote_execute.rb: action_run(#{new_resource.command}) "\
-                      "return code #{r[2]}, "\
-                      "stdout #{r[0]}, "\
-                      "stderr #{r[1]}")
-      # check return code?
-      success = allowed_exit_codes.include?(r[2])
+      stdout, stderr, exit_code, exit_signal = ssh_exec(session,
+                                                        new_resource.command,
+                                                        command_options)
+
+      success = allowed_exit_codes.include?(exit_code)
       unless success
         error_parts = [
-          "Expected process to exit with #{allowed_exit_codes.inspect}, but received #{r[2]}",
+          "Expected process to exit with #{allowed_exit_codes.inspect}, but received #{exit_code} (signal: #{exit_signal})",
         ]
-        if new_resource.sensitive
+        if new_resource.sensitive_output
           error_parts.push(
             'STDOUT/STDERR suppressed for sensitive resource'
           )
-        else
+        elsif !stdout.nil? || !stderr.nil?
           error_parts.push(
             "---- Begin output of #{descriptor} ----",
-            "STDOUT: #{r[0]}",
-            "STDERR: #{r[1]}",
+            "STDOUT: #{stdout}",
+            "STDERR: #{stderr}",
             "---- End output of #{descriptor}----"
           )
         end
@@ -90,15 +98,18 @@ end
 
 action_class do
   def eval_guard(session, guard_command_config)
-    command = guard_command_config.fetch(:command)
-    request_pty = guard_command_config.fetch(:request_pty)
-    eval_command(session, command, request_pty)
+    guard_command_config = guard_command_config.dup
+    command = guard_command_config.delete(:command)
+    guard_command_config.delete(:sensitive_command)
+    eval_command(session, command, guard_command_config)
   end
 
-  def eval_command(session, command, with_pty)
-    rc = ssh_exec(session, command, request_pty: with_pty)
-    Chef::Log.debug("eval_command: stdout: #{rc[0]}")
-    Chef::Log.debug("eval_command: stderr: #{rc[1]}")
+  def eval_command(session, command, sensitive_output: false, **options)
+    rc = ssh_exec(session, command, options)
+    unless sensitive_output
+      Chef::Log.debug("eval_command: stdout: #{rc[0]}")
+      Chef::Log.debug("eval_command: stderr: #{rc[1]}")
+    end
     return true if rc[2] == 0
     false
   end
@@ -113,6 +124,11 @@ action_class do
       retval = yield session
     end
     retval
+  end
+
+  def masked_command(command, sensitive)
+    return '(suppressed sensitive command)' if sensitive
+    command
   end
 
   def exec_io(session, command, input: nil, request_pty: false)
@@ -154,13 +170,12 @@ action_class do
     [status_obj[:exit_code], status_obj[:exit_signal]]
   end
 
-  def ssh_exec(session, command, input: nil, request_pty: false)
+  def ssh_exec(session, command, options)
     stdout_data = ''
     stderr_data = ''
     exit_code, exit_signal = exec_io(session,
                                      command,
-                                     input: input,
-                                     request_pty: request_pty) do |_channel, stream, data|
+                                     options) do |_channel, stream, data|
       stderr_data += data if stream == :stderr
       stdout_data += data if stream == :stdout
     end

--- a/resources/remote_execute.rb
+++ b/resources/remote_execute.rb
@@ -139,10 +139,9 @@ action_class do
         end
         channel.on_request('exit-status') { |_, data| exit_code = data.read_long }
         channel.on_request('exit-signal') { |_, data| exit_signal = data.read_long }
-        unless input.nil?
-          channel.send_data(input)
-          channel.eof!
-        end
+        channel.send_data(input) unless input.nil?
+        # Always send EOF to prevent things from getting stuck unintentionally.
+        channel.eof!
       end
     end.wait
     [stdout_data, stderr_data, exit_code, exit_signal]

--- a/test/cookbooks/test/recipes/exectest.rb
+++ b/test/cookbooks/test/recipes/exectest.rb
@@ -251,3 +251,5 @@ remote_execute 'array not_if_remote guard' do
   address 'localhost'
   not_if_remote ['test', '!', '-f', '/tmp/guard target file']
 end
+
+include_recipe 'test::ptytest'

--- a/test/cookbooks/test/recipes/exectest.rb
+++ b/test/cookbooks/test/recipes/exectest.rb
@@ -253,3 +253,10 @@ remote_execute 'array not_if_remote guard' do
 end
 
 include_recipe 'test::ptytest'
+
+# Check that EOF is always sent. The following resource would timeout otherwise.
+remote_execute 'cat' do
+  user 'testuser'
+  password node['test-cookbook']['testuser']['password']
+  address 'localhost'
+end

--- a/test/cookbooks/test/recipes/ptytest.rb
+++ b/test/cookbooks/test/recipes/ptytest.rb
@@ -1,0 +1,113 @@
+# Check if PTY allocation for the command works
+
+remote_execute 'PTY positive true' do
+  command 'test -t 0'
+  request_pty true
+  user 'testuser'
+  password node['test-cookbook']['testuser']['password']
+  address 'localhost'
+end
+
+remote_execute 'PTY negative true' do
+  command 'test ! -t 0'
+  request_pty true
+  user 'testuser'
+  password node['test-cookbook']['testuser']['password']
+  address 'localhost'
+  returns 1
+end
+
+remote_execute 'PTY positive default' do
+  command 'test ! -t 0'
+  user 'testuser'
+  password node['test-cookbook']['testuser']['password']
+  address 'localhost'
+end
+
+remote_execute 'PTY negative default' do
+  command 'test -t 0'
+  user 'testuser'
+  password node['test-cookbook']['testuser']['password']
+  address 'localhost'
+  returns 1
+end
+
+# Check if PTY allocation for not_if_remote works
+
+remote_execute 'not_if_remote PTY positive true' do
+  # make the command fail if it is executed
+  command 'false'
+  request_pty true
+  user 'testuser'
+  password node['test-cookbook']['testuser']['password']
+  address 'localhost'
+  not_if_remote command: 'test -t 0', request_pty: true
+end
+
+remote_execute 'not_if_remote PTY positive :guards' do
+  # make the command fail if it is executed
+  command 'false'
+  user 'testuser'
+  password node['test-cookbook']['testuser']['password']
+  address 'localhost'
+  not_if_remote command: 'test -t 0', request_pty: true
+end
+
+remote_execute 'not_if_remote PTY negative :command' do
+  # make the command fail if it is executed
+  command 'false'
+  request_pty true
+  user 'testuser'
+  password node['test-cookbook']['testuser']['password']
+  address 'localhost'
+  not_if_remote command: 'test ! -t 0', request_pty: false
+end
+
+remote_execute 'not_if_remote PTY negative default' do
+  # make the command fail if it is executed
+  command 'false'
+  user 'testuser'
+  password node['test-cookbook']['testuser']['password']
+  address 'localhost'
+  not_if_remote command: 'test ! -t 0', request_pty: false
+end
+
+# Check if PTY allocation for only_if_remote works
+
+remote_execute 'only_if_remote PTY positive true' do
+  # make the command fail if it is executed
+  command 'false'
+  request_pty true
+  user 'testuser'
+  password node['test-cookbook']['testuser']['password']
+  address 'localhost'
+  only_if_remote command: 'test ! -t 0', request_pty: true
+end
+
+remote_execute 'only_if_remote PTY positive :guards' do
+  # make the command fail if it is executed
+  command 'false'
+  user 'testuser'
+  password node['test-cookbook']['testuser']['password']
+  address 'localhost'
+  only_if_remote command: 'test ! -t 0', request_pty: true
+end
+
+remote_execute 'only_if_remote PTY negative :command' do
+  # make the command fail if it is executed
+  command 'false'
+  request_pty true
+  user 'testuser'
+  password node['test-cookbook']['testuser']['password']
+  address 'localhost'
+  only_if_remote command: 'test -t 0', request_pty: false
+end
+
+remote_execute 'only_if_remote PTY negative default' do
+  # make the command fail if it is executed
+  command 'false'
+  user 'testuser'
+  password node['test-cookbook']['testuser']['password']
+  address 'localhost'
+  only_if_remote command: 'test -t 0', request_pty: false
+end


### PR DESCRIPTION
#### Change summary

- Support for requesting a PTY for execution of guards and commands. This also extends the remote guard syntax to take a hash as argument to allow for additional flags.
- Ensure that EOF is always sent to prevent runs from getting stuck when they unexpectedly request input. Note that this does not work reliably with PTYs due to how PTYs and EOF on PTYs work.
- Use the same mechanism as used for ``request_pty`` for ``sensitive`` to allow fine-grained control over sensitiveness.